### PR TITLE
fix: style corrections and preparing for v1.0

### DIFF
--- a/src/ansi_base.rs
+++ b/src/ansi_base.rs
@@ -4,6 +4,7 @@ pub const DIM: &str = "\x1b[2m";
 pub const ITALIC: &str = "\x1b[3m";
 pub const UNDERLINE: &str = "\x1b[4m";
 
+// FIX!: ASAP: what the actual fucking fuck just return boolean
 /// Check if the terminal supports ANSI colors
 pub fn is_color_available() -> Result<(), &'static str> {
     if std::env::var("TERM").is_ok() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+// FIX: ASAP: re-design this cursed module structure
 use crate::ansi_base::{BOLD, DIM, ITALIC, RESET, UNDERLINE};
 use std::fmt;
 
@@ -43,11 +44,14 @@ impl fmt::Display for ColoredString {
     }
 }
 
+// FIX!: LATER: trait name should be verb
 /// Trait for types that can be styled with a `Style`
 pub trait Stylish {
+    // FIX!: LATER: trait's only method should have consistent name with the trait
     fn styled(self, style: Style) -> ColoredString;
 }
 
+// FIX: blanket impl for everything that implements `ToString` or `AsRef<str>`
 impl Stylish for String {
     fn styled(self, style: Style) -> ColoredString {
         ColoredString::new(&self, style)
@@ -121,6 +125,7 @@ impl Style {
     }
 }
 
+// FIX!: unnecessary builder pattern
 /// A builder struct for constructing a `Style` instance with various configurations.
 pub struct StyleBuilder {
     style: Style,
@@ -152,6 +157,7 @@ impl StyleBuilder {
     ///     .build();
     /// ```
     pub fn foreground(mut self, color: Color) -> Self {
+        // FIX!: ASAP: take & return mutable reference rather than taking ownership
         // | e.g. (&mut self, color: Color) -> &mut Self
         // | also applys to every builder pattern methods below
         self.style.foreground = color;
@@ -329,6 +335,7 @@ impl Color {
             Color::Empty => "".to_string(),
             Color::RGB(r, g, b) => format!("\x1b[38;2;{};{};{}m", r, g, b),
             Color::HEX(code) => {
+                // FIX: converting str to integer and back to String
                 let (r, g, b) = match Self::hex_to_rgb(code) {
                     Some(rgb) => rgb,
                     None => panic!("Invalid hex code: {}", code),
@@ -342,6 +349,7 @@ impl Color {
     /// Converts the `Color` enum variant to its corresponding background ANSI escape code string.
     fn to_bg(self) -> String {
         match self {
+            // FIX!: use `Cow<'static, str>` to avoid `to_string()`
             Color::Black => "\x1b[40m".to_string(),
             Color::Red => "\x1b[41m".to_string(),
             Color::Green => "\x1b[42m".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -392,14 +392,11 @@ impl Color {
             return None;
         }
 
-        let r = u8::from_str_radix(&hex[0..2], 16).ok();
-        let g = u8::from_str_radix(&hex[2..4], 16).ok();
-        let b = u8::from_str_radix(&hex[4..6], 16).ok();
+        let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+        let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+        let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
 
-        match (r, g, b) {
-            (Some(r), Some(g), Some(b)) => Some((r, g, b)),
-            _ => None,
-        }
+        Some((r, g, b))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,8 +2,10 @@ use crate::ansi_base::{BOLD, DIM, ITALIC, RESET, UNDERLINE};
 use std::fmt;
 
 /// String with the colored text
+///
 /// # Example
-/// ```rust
+///
+/// ```
 /// use inksac::types::*;
 ///
 /// let TITLESTYLE: Style = Style{
@@ -51,6 +53,7 @@ impl Stylish for String {
         ColoredString::new(&self, style)
     }
 }
+
 impl<'a> Stylish for &'a str {
     fn styled(self, style: Style) -> ColoredString {
         ColoredString::new(self, style)
@@ -81,6 +84,7 @@ pub struct Style {
     pub italic: bool,
     pub underline: bool,
 }
+
 impl fmt::Display for Style {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let fg = if self.foreground != Color::Empty {
@@ -148,6 +152,8 @@ impl StyleBuilder {
     ///     .build();
     /// ```
     pub fn foreground(mut self, color: Color) -> Self {
+        // | e.g. (&mut self, color: Color) -> &mut Self
+        // | also applys to every builder pattern methods below
         self.style.foreground = color;
         self
     }
@@ -288,28 +294,13 @@ impl StyleBuilder {
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Color {
-    /// Black color.
     Black,
-
-    /// Red color.
     Red,
-
-    /// Green color.
     Green,
-
-    /// Yellow color.
     Yellow,
-
-    /// Blue color.
     Blue,
-
-    /// Magenta color.
     Magenta,
-
-    /// Cyan color.
     Cyan,
-
-    /// White color.
     White,
 
     /// Represents an absence of color.
@@ -322,6 +313,7 @@ pub enum Color {
     /// Specifies a color using a hexadecimal color code.
     HEX(&'static str),
 }
+
 impl Color {
     /// Converts the `Color` enum variant to its corresponding foreground ANSI escape code string.
     fn to_fg(self) -> String {
@@ -376,9 +368,11 @@ impl Color {
     /// This is used internally by the `to_fg` and `to_bg` methods when handling `Color::HEX` variants.
     ///
     /// # Parameters
+    ///
     /// - `hex`: A string slice representing the hexadecimal color code.
     ///
     /// # Returns
+    ///
     /// A tuple of three `u8` values representing the red, green, and blue components of the color, respectively.
     ///
     fn hex_to_rgb(hex: &str) -> Option<(u8, u8, u8)> {
@@ -387,8 +381,9 @@ impl Color {
         // if the length of the hex string is not 6, panic the code
         // Since the terminal does not support `RGBA` colors anyway
         if hex.len() != 6 {
-            panic!("Invalid hex color length: {}", hex);
+            return None;
         }
+
         let r = u8::from_str_radix(&hex[0..2], 16).ok();
         let g = u8::from_str_radix(&hex[2..4], 16).ok();
         let b = u8::from_str_radix(&hex[4..6], 16).ok();


### PR DESCRIPTION
I tried my best to make the code more idiomatic Rust without breaking the API, but the structure and the approach of this library is fundamentally malformed and cannot be corrected without redesigning the majority of the code.

I have marked some significant spots that must be addressed in the next major version.